### PR TITLE
Fix meta-tx domain separator chainId caching

### DIFF
--- a/contracts/Aavegotchi/facets/MetaTransactionsFacet.sol
+++ b/contracts/Aavegotchi/facets/MetaTransactionsFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.1;
 
 import {LibDiamond} from "../../shared/libraries/LibDiamond.sol";
+import {LibMeta} from "../../shared/libraries/LibMeta.sol";
 import {AppStorage} from "../libraries/LibAppStorage.sol";
 
 contract MetaTransactionsFacet {
@@ -22,7 +23,8 @@ contract MetaTransactionsFacet {
     }
 
     function getDomainSeparator() private view returns (bytes32) {
-        return s.domainSeparator;
+        // Compute dynamically so signatures cannot be replayed if the chainId changes.
+        return LibMeta.domainSeparator("AavegotchiDiamond", "V1");
     }
 
     /**


### PR DESCRIPTION
MetaTransactionsFacet now computes the EIP-712 domain separator dynamically (using the current chainId) instead of relying on the cached value in AppStorage.

Why:
- If chainId changes (fork/migration), cached domain separators allow signature replay across chainIds.

Tests:
- npx hardhat compile